### PR TITLE
Fix EnvInteractData with Python3.9

### DIFF
--- a/denoised_mdp/envs/interaction.py
+++ b/denoised_mdp/envs/interaction.py
@@ -10,6 +10,9 @@ import sys
 if sys.version_info < (3, 8):
     from typing_extensions import Protocol
 
+if sys.version_info < (3, 11):
+    from typing_extensions import NamedTuple
+
 import abc
 import contextlib
 import dataclasses
@@ -46,8 +49,7 @@ class StateProtocol(Protocol):
 StateT = TypeVar('StateT', bound=StateProtocol)
 
 
-@dataclasses.dataclass
-class EnvInteractData(Generic[StateT]):  # thank god we py37 https://stackoverflow.com/a/50531189
+class EnvInteractData(NamedTuple, Generic[StateT]):  # thank god we py37 https://stackoverflow.com/a/50531189
     r"""
     All information about the last step taken.
     """

--- a/denoised_mdp/envs/interaction.py
+++ b/denoised_mdp/envs/interaction.py
@@ -46,7 +46,8 @@ class StateProtocol(Protocol):
 StateT = TypeVar('StateT', bound=StateProtocol)
 
 
-class EnvInteractData(NamedTuple, Generic[StateT]):  # thank god we py37 https://stackoverflow.com/a/50531189
+@dataclasses.dataclass
+class EnvInteractData(Generic[StateT]):  # thank god we py37 https://stackoverflow.com/a/50531189
     r"""
     All information about the last step taken.
     """


### PR DESCRIPTION
This fixes https://github.com/facebookresearch/denoised_mdp/issues/4 by changing the namedtuple to a dataclass.